### PR TITLE
Magento CSP Whitelist

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Tawk.to
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to support@tawk.to so we can send you a copy immediately.
+ *
+ * @copyright   Copyright (c) 2021 Tawk.to
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+-->
+
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp/etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="style-src">
+            <values>
+                <value id="googleapis-font" type="host">fonts.googleapis.com</value>
+                <value id="jsdelivr-cdn" type="host">cdn.jsdelivr.net</value>
+            </values>
+        </policy>
+        <policy id="script-src">
+            <values>
+                <value id="tawkto" type="host">*.tawk.to</value>
+                <value id="jsdelivr-cdn" type="host">cdn.jsdelivr.net</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="tawkto" type="host">*.tawk.to</value>
+            </values>
+        </policy>
+        <policy id="font-src">
+            <values>
+                <value id="tawkto" type="host">*.tawk.to</value>
+                <value id="gstatic-fonts" type="host">fonts.gstatic.com</value>
+            </values>
+        </policy>
+        <policy id="img-src">
+            <values>
+                <value id="tawkto" type="host">*.tawk.to</value>
+                <value id="jsdelivr-cdn" type="host">cdn.jsdelivr.net</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="tawkto" type="host">*.tawk.to</value>
+                <value id="tawkto-wss" type="host">wss://*.tawk.to</value>
+            </values>
+        </policy>
+        <policy id="form-action">
+            <values>
+                <value id="tawkto" type="host">*.tawk.to</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
The module is having issues with Magento's CSP module. The CSP module prevented third-party iframes and scripts to load since it was considered as "malicious" and needs to be whitelisted.

So I added a `csp_whitelist.xml` file and there included the domains that the module is loading.

See [Magento's CSP module](https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/content-security-policies.html) for more info about this.

Tested this for Magento 2.3.5-p1 and 2.4.1