### PR TITLE
Magento layout handle support on Visibility Options.

### DIFF
--- a/Block/Embed.php
+++ b/Block/Embed.php
@@ -261,6 +261,7 @@ class Embed extends Template
         });
         if (empty($checkHandles)) return false;
 
+        $existHandle = false;
         $currentPageHandles = $this->layout->getUpdate()->getHandles();
         foreach ($currentPageHandles as $handle) {
             if (in_array($handle, $checkHandles)) {
@@ -268,6 +269,6 @@ class Embed extends Template
                 break;
             }
         }
-        return isset($existHandle) ? true : false;
+        return $existHandle;
     }
 }

--- a/Block/Embed.php
+++ b/Block/Embed.php
@@ -203,6 +203,7 @@ class Embed extends Template
                     $current_url = trim(strtolower($current_url));
 
                     $excluded_url_list = preg_split("/,/", $excluded_url_list);
+                    $excluded_url_list = array_map('trim', $excluded_url_list);
                     if (UrlPatternMatcher::match($current_url, $excluded_url_list)) {
                         $display = false;
                     }
@@ -233,6 +234,7 @@ class Embed extends Template
                     $current_url = trim(strtolower($current_url));
 
                     $included_url_list = preg_split("/,/", $included_url_list);
+                    $included_url_list = array_map('trim', $included_url_list);
                     if (UrlPatternMatcher::match($current_url, $included_url_list)) {
                         $display = true;
                     }

--- a/view/adminhtml/templates/selectwidget.phtml
+++ b/view/adminhtml/templates/selectwidget.phtml
@@ -56,11 +56,15 @@
         </div>
         <div class="tawk-fields" id="exlucded_urls_container">
             <label for="excludeurl">
-                (Exception) hide tawk.to widget to the following URLs or paths. Separate each entry with a comma(,).
+                (Exception) hide tawk.to widget to the following URLs or paths. Separate each entry with a comma(,).<br>
+                Layout handles (catalog_category_view, catalog_product_view, ...) are also supported. If a layout handle is present, others are ignored.<br>
             </label>
             <div class="tawk-tooltip">
                 Examples of accepted patterns
                 <ul class="tawk-tooltiptext">
+                    <li>catalog_category_view</li>
+                    <li>catalog_product_view</li>
+                    <li>cms_index_index</li>
                     <li>*</li>
                     <li>*/to/somewhere</li>
                     <li>/*/to/somewhere</li>
@@ -98,11 +102,15 @@
         </div>
         <div class="tawk-fields"  id="included_urls_container">
             <label for="includeurl">
-                (Exception) display tawk.to widget to the following URLs or paths. Separate each entry with a comma(,).
+                (Exception) display tawk.to widget to the following URLs or paths. Separate each entry with a comma(,).<br>
+                Layout handles (catalog_category_view, catalog_product_view, ...) are also supported. If a layout handle is present, others are ignored.<br>
             </label>
             <div class="tawk-tooltip">
                 Examples of accepted patterns
                 <ul class="tawk-tooltiptext">
+                    <li>catalog_category_view</li>
+                    <li>catalog_product_view</li>
+                    <li>cms_index_index</li>                    
                     <li>*</li>
                     <li>*/to/somewhere</li>
                     <li>/*/to/somewhere</li>


### PR DESCRIPTION
In determining the display position, I've modified to support Magento layout handles in the Visibility Options.

For example:

- Category Page (catalog_category_view)
- Product Page (catalog_product_view)
- Homepage (cms_index_index)
- Search Result Page (catalogsearch_result_index)
- Cart Page (checkout_cart_index)
- Checkout Page (checkout_onepage_index)
- Customer Login Page (customer_account_login)
- Customer Account Create Page (customer_account_create)
- Customer Account Edit Page (customer_account_edit)
- All Pages (default)
- Other Magento layout handles you want ....

![image](https://github.com/user-attachments/assets/a4904163-ffaa-4758-8779-09a4670e8be8)
