### PR TITLE
[fix] Compatibility among Magento 2 versions

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -6,7 +6,6 @@ use Magento\Framework\Setup\UpgradeDataInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use Zend_Uri_Http;
 
 use Tawk\Helpers\PathHelper;
 use Tawk\Widget\Model\WidgetFactory;
@@ -94,14 +93,15 @@ class UpgradeData implements UpgradeDataInterface
         $storeHost = '';
 
         $storeUrl = $this->_modelStoreManager->getStore($storeId)->getBaseUrl();
-        $parsedUrl = Zend_Uri_Http::fromString($storeUrl);
+        //phpcs:ignore Magento2.Functions.DiscouragedFunction.Discouraged
+        $parsedUrl = parse_url($storeUrl);
 
-        if ($parsedUrl->getHost() !== false) {
-            $storeHost = $parsedUrl->getHost();
+        if (!empty($parsedUrl['host'])) {
+            $storeHost = $parsedUrl['host'];
         }
 
-        if ($parsedUrl->getPort() !== false) {
-            $storeHost .= ':' . $parsedUrl->getPort();
+        if (!empty($parsedUrl['port'])) {
+            $storeHost .= ':' . $parsedUrl['port'];
         }
 
         return $storeHost;

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -116,7 +116,10 @@ class UpgradeData implements UpgradeDataInterface
      */
     private function addWildcardToPatternList($patternList, $storeHost)
     {
-        $splittedPatternList = preg_split("/,/", $patternList);
+        if (empty($patternList)) {
+            return '';
+        }
+        $splittedPatternList = preg_split("/,/", (string)$patternList);
         $wildcard = PathHelper::get_wildcard();
 
         $newPatternList = [];


### PR DESCRIPTION
Error log while upgrading version on Magento >= 2.4.4
```
There is an error in /vendor/tawk/widget/Setup/UpgradeData.php at line: 97
Class "Zend_Uri_Http" not found#0 /vendor/tawk/widget/Setup/UpgradeData.php(75): Tawk\Widget\Setup\UpgradeData->getStoreHost()
#1 /vendor/tawk/widget/Setup/UpgradeData.php(54): Tawk\Widget\Setup\UpgradeData->versionUpdate160()
```

Apparently, this was not completely support Magento >= 2.4.4 as https://github.com/tawk/tawk-magento-2/blob/v1.6.0/Setup/UpgradeData.php#L97 Zend_Uri_Http was removed, in this case to make thing compatibility support Magento >= 2.4.4 and Magento < 2.4.4 consider to use:
parse_url()

Or use Laminas\Uri\Http for support Magento >= 2.4.4 only


Fix https://github.com/tawk/tawk-magento-2/issues/37